### PR TITLE
Make destroyer always play the easteregg sound

### DIFF
--- a/src/main/java/com/buncord/kirbyessentials/block_entities/FireproofDestroyerBlockEntity.java
+++ b/src/main/java/com/buncord/kirbyessentials/block_entities/FireproofDestroyerBlockEntity.java
@@ -181,20 +181,14 @@ public class FireproofDestroyerBlockEntity extends RandomizableContainerBlockEnt
           entity.getItems().clear();
           entity.setChanged();
 
-          Random random = new Random();
-
-          int randomInt = random.nextInt(10);
-
-          if (randomInt == 0) {
-            level.playSound(
-                null,
-                blockPos,
-                ModSounds.FIREPROOF_DESTROYER.get(),
-                SoundSource.BLOCKS,
-                0.5F,
-                1F
-            );
-          }
+          level.playSound(
+              null,
+              blockPos,
+              ModSounds.FIREPROOF_DESTROYER.get(),
+              SoundSource.BLOCKS,
+              0.5F,
+              1F
+          );
         }
 
         entity.ticks = 0;


### PR DESCRIPTION
Changing this just to make it more likely for them to discover all eastereggs before Kirby ends.